### PR TITLE
Update website information

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@
                     <h5 class="title-sm v-spacing-md">Nasjonal Finale</h5>
                     <div class="upper v-spacing-sm">
                         <span class="text-red h-spacing-md">Dato</span>
-                        7. Juni - 12. Juni
+                        7. Juni - 9. Juni
                     </div>
                     <div class="upper v-spacing-sm">
                         <span class="text-red h-spacing-md">Sted</span>

--- a/index.html
+++ b/index.html
@@ -85,7 +85,6 @@
     </div>
 
     <!-- Intro -->
-    <a class="neon-text title-lg2 flex-center pad-block-sm" href="https://ctf.cyberlandslaget.no">CTF LIVE, KLIKK HER</a>
     <div class="grid intro-grid container pad-block-md">
 
         <div>
@@ -129,7 +128,7 @@
                     <h5 class="title-sm v-spacing-md">Semifinale</h5>
                     <div class="upper v-spacing-sm">
                         <span class="text-red h-spacing-md">Dato</span>
-                        April
+                        8. Mai - 12. Mai
                     </div>
                     <div class="upper v-spacing-sm">
                         <span class="text-red h-spacing-md">Sted</span>
@@ -141,7 +140,7 @@
                     <h5 class="title-sm v-spacing-md">Nasjonal Finale</h5>
                     <div class="upper v-spacing-sm">
                         <span class="text-red h-spacing-md">Dato</span>
-                        Mai
+                        7. Juni - 12. Juni
                     </div>
                     <div class="upper v-spacing-sm">
                         <span class="text-red h-spacing-md">Sted</span>
@@ -153,11 +152,11 @@
                     <h5 class="title-sm v-spacing-md">ECSC 2024</h5>
                     <div class="upper v-spacing-sm">
                         <span class="text-red h-spacing-md">Dato</span>
-                        TBA
+                        07. Oktober - 11. Oktober
                     </div>
                     <div class="upper v-spacing-sm">
                         <span class="text-red h-spacing-md">Sted</span>
-                        Italia
+                        Turin, Italia
                     </div>
                 </div>
             </div>

--- a/kontakt.html
+++ b/kontakt.html
@@ -83,7 +83,6 @@
     <a class="nav-link" href="https://discord.gg/FBDHVZ89zk">Join oss på discord</a>
     <span class="material-symbols-outlined">arrow_outward</span>
 </div>
-  <a class="neon-text title-lg2 flex-center pad-block-sm" href="https://ctf.cyberlandslaget.no">CTF LIVE, KLIKK HER</a>
   <div class="pad-block-lg container grid grid-col-2">
       <div>
           <h2 class="title-lg v-spacing-lg">Kontakt Oss</h2>

--- a/landslaget.html
+++ b/landslaget.html
@@ -83,7 +83,6 @@
         <a class="nav-link" href="https://discord.gg/FBDHVZ89zk">Join oss på discord</a>
         <span class="material-symbols-outlined">arrow_outward</span>
     </div>
-    <a class="neon-text title-lg2 flex-center pad-block-sm" href="https://ctf.cyberlandslaget.no">CTF LIVE, KLIKK HER</a>
     <div class="pad-block-lg container">
       <img class="v-spacing-lg" src="/Landslaget.png" alt="">
         <div class="flex flex-v flex-h-center">

--- a/om-oss.html
+++ b/om-oss.html
@@ -83,7 +83,6 @@
         <a class="nav-link" href="https://discord.gg/FBDHVZ89zk">Join oss på discord</a>
         <span class="material-symbols-outlined">arrow_outward</span>
     </div>
-    <a class="neon-text title-lg2 flex-center pad-block-sm" href="https://ctf.cyberlandslaget.no">CTF LIVE, KLIKK HER</a>
     <div class="pad-block-lg container grid grid-col-2">
         <div>
             <h2 class="title-lg v-spacing-lg">Om Oss</h2>


### PR DESCRIPTION
# Changelog

- Remove CTF Live text
- Add semi-finale, and finale date from Cyberlandslaget discord
- Add ECSC 2024 dates from https://ecsc2024.it/
- Update ECSC location to be more specific.